### PR TITLE
STAR alignment wrapper containing 2 pass alignment and use of metadata sheet

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,9 +27,9 @@ RUN     tar xvzf tophat-2.0.12.tar.gz
 RUN     cd /opt/tophat-2.0.12 && ./configure --prefix=/opt --with-boost-libdir=/usr/lib/x86_64-linux-gnu/ && make && make install
 
 #install STAR
-RUN     wget https://github.com/alexdobin/STAR/archive/STAR_2.4.0f1.tar.gz
-RUN     tar xvzf STAR_2.4.0f1.tar.gz
-RUN     cp /opt/STAR-STAR_2.4.0f1/bin/Linux_x86_64/STAR /opt/bin/
+RUN     wget https://github.com/alexdobin/STAR/archive/STAR_2.4.0g1.tar.gz
+RUN     tar xvzf STAR_2.4.0g1.tar.gz
+RUN     cp /opt/STAR-STAR_2.4.0g1/bin/Linux_x86_64/STAR /opt/bin/
 
 #install python packages
 RUN     pip install lxml

--- a/cghub_submit/analysis.pcawg_rnaseq.STAR_template.xml
+++ b/cghub_submit/analysis.pcawg_rnaseq.STAR_template.xml
@@ -104,7 +104,7 @@
               <STEP_INDEX>mapping</STEP_INDEX>
               <PREV_STEP_INDEX>NIL</PREV_STEP_INDEX>
               <PROGRAM>STAR</PROGRAM>
-              <VERSION>2.4.0f1</VERSION>
+              <VERSION>2.4.0g1</VERSION>
               <NOTES>STAR --genomeDir hg19_GRCh37.p13_STAR_gencode19.overhang100 --readFilesIn left.fastq right.fastq --runThreadN runThreadN --outFilterMultimapScoreRange 1 --outFilterMultimapNmax 20 --outFilterMismatchNmax 10 --alignIntronMax 500000 --alignMatesGapMax 1000000 --sjdbScore 2 --alignSJDBoverhangMin 1 --genomeLoad NoSharedMemory --readFilesCommand bzcat --outFilterMatchNminOverLread 0.33 --outFilterScoreMinOverLread 0.33 --outSAMstrandField intronMotif --outSAMattributes NH HI NM MD AS XS --outSAMunmapped Within --outSAMtype BAM Unsorted</NOTES>
             </PIPE_SECTION>
           </PIPELINE>
@@ -144,7 +144,7 @@
       </ANALYSIS_ATTRIBUTE>
       <ANALYSIS_ATTRIBUTE>
         <TAG>STAR_version</TAG>
-        <VALUE>2.4.0f1</VALUE>
+        <VALUE>2.4.0g1</VALUE>
       </ANALYSIS_ATTRIBUTE>
     </ANALYSIS_ATTRIBUTES>
   </ANALYSIS>

--- a/star_align.py
+++ b/star_align.py
@@ -158,7 +158,7 @@ if __name__ == "__main__":
     optional = parser.add_argument_group("optional input parameters")
     optional.add_argument("--out", default="out.bam", help="Name of the output BAM file")
     optional.add_argument("--workDir", default="./", help="Work directory")
-    optional.add_argument("--metaData", default=None, help="File containing metadata for the alignment header")
+    optional.add_argument("--metaDataTab", default=None, help="File containing metadata for the alignment header")
     optional.add_argument("--analysisID", default=None, help="Analysis ID to be considered in the metadata file")
     optional.add_argument("--keepJunctions", default=False, action='store_true', help="keeps the junction file as {--out}.junctions")
     optional.add_argument("--useTMP", default=None, help="environment variable that is used as prefix for temprary data")
@@ -196,9 +196,9 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     ### some sanity checks on command line parameters
-    if args.metaData is not None:
-        if not os.path.exists(args.metaData):
-            raise Exception("File provided via --metaData does not exist\nFile: %s" % args.metaData)
+    if args.metaDataTab is not None:
+        if not os.path.exists(args.metaDataTab):
+            raise Exception("File provided via --metaDataTab does not exist\nFile: %s" % args.metaDataTab)
         if args.analysisID is None:
             raise Exception("When providing information in a metadata file, a value for --analysisID is required")
     if args.outSAMattrRGxml is not None and not os.path.exists(args.outSAMattrRGxml):
@@ -355,8 +355,8 @@ if __name__ == "__main__":
         })
 
     ### process read group information
-    if args.metaData is not None:
-        RG_dict = spreadsheet2RGdict(args.metaData, args.analysisID) 
+    if args.metaDataTab is not None:
+        RG_dict = spreadsheet2RGdict(args.metaDataTab, args.analysisID) 
     elif args.outSAMattrRGxml is not None:
         RG_dict = xml2RGdict(args.outSAMattrRGxml)
     elif args.outSAMattrRGline is not None:

--- a/star_align.py
+++ b/star_align.py
@@ -118,6 +118,7 @@ if __name__ == "__main__":
     optional.add_argument("--workDir", default="./", help="Work directory")
     optional.add_argument("--keepJunctions", default=False, action='store_true', help="keeps the junction file as {--out}.junctions")
     optional.add_argument("--useTMP", default=None, help="environment variable that is used as prefix for temprary data")
+    optional.add_argument("--weakRGcheck", action='store_true', default=False, help="only perform weak RG record check and generate generic RG ID in case of a single alignment file with multiple RG records present. Use with caution!")
     optional.add_argument("-h", "--help", action='store_true', help="show this help message and exit")
     star = parser.add_argument_group("STAR input parameters")
     star.add_argument("--runThreadN", type=int, default=4, help="Number of threads")
@@ -129,9 +130,10 @@ if __name__ == "__main__":
     star.add_argument("--sjdbScore", type=int, default=2, help="sjdbScore")
     star.add_argument("--alignSJDBoverhangMin", type=int, default=1, help="alignSJDBoverhangMin")
     star.add_argument("--genomeLoad", default="NoSharedMemory", help="genomeLoad")
+    star.add_argument("--genomeFastaFiles", default=None, help="genome sequence in fasta format to rebuild index")
     star.add_argument("--outFilterMatchNminOverLread", type=float, default=0.33, help="outFilterMatchNminOverLread")
     star.add_argument("--outFilterScoreMinOverLread", type=float, default=0.33, help="outFilterScoreMinOverLread")
-    star.add_argument("--twopass1readsN", type=int, default=0, help="twopass1readsN (-1 means all reads are used for remapping)")
+    star.add_argument("--twopass1readsN", type=int, default=-1, help="twopass1readsN (-1 means all reads are used for remapping)")
     star.add_argument("--sjdbOverhang", type=int, default=100, help="sjdbOverhang (only necessary for two-pass mode)")
     star.add_argument("--outSAMstrandField", default="intronMotif", help="outSAMstrandField")
     star.add_argument("--outSAMattributes", default=["NH", "HI", "NM", "MD", "AS", "XS"], help="outSAMattributes")
@@ -160,6 +162,8 @@ if __name__ == "__main__":
         tarcmd = "tar xvjf %s -C %s" % (args.tarFileIn, workdir)
     elif args.tarFileIn.endswith(".tar"):
         tarcmd = "tar xvf %s -C %s" % (args.tarFileIn, workdir)
+    else:
+        raise Exception("Unknown input file extension for file %s" % (args.tarFileIn))
     subprocess.check_call(tarcmd, shell=True)
     
     ### collect fastq information from extraction dir
@@ -170,6 +174,80 @@ if __name__ == "__main__":
     else:
         read_str = '${fastq_left}'
     
+    ### simulate two pass alignment until STAR fully implements this
+    if args.twopass1readsN != 0:
+        
+        ### run first round of alignments and only record junctions
+        align_template_str_1st = """STAR \
+--genomeDir ${genomeDir} --readFilesIn %s \
+--runThreadN ${runThreadN} \
+--outFilterMultimapScoreRange ${outFilterMultimapScoreRange} \
+--outFilterMultimapNmax ${outFilterMultimapNmax} \
+--outFilterMismatchNmax ${outFilterMismatchNmax} \
+--alignIntronMax ${alignIntronMax} \
+--alignMatesGapMax ${alignMatesGapMax} \
+--sjdbScore ${sjdbScore} \
+--alignSJDBoverhangMin ${alignSJDBoverhangMin} \
+--genomeLoad ${genomeLoad} \
+--readFilesCommand ${readFilesCommand} \
+--outFilterMatchNminOverLread ${outFilterMatchNminOverLread} \
+--outFilterScoreMinOverLread ${outFilterScoreMinOverLread} \
+--sjdbOverhang ${sjdbOverhang} \
+--outSAMstrandField ${outSAMstrandField} \
+--outSAMtype None \
+--outSAMmode None""" % read_str
+
+        if args.twopass1readsN > 0:
+            align_template_str_1st += " --readMapNumber %i" % args.twopass1readsN
+
+        cmd = string.Template(align_template_str_1st).safe_substitute({
+            'genomeDir' : os.path.abspath(args.genomeDir),
+            'runThreadN' : args.runThreadN,
+            'outFilterMultimapScoreRange' : args.outFilterMultimapScoreRange,
+            'outFilterMultimapNmax' : args.outFilterMultimapNmax,
+            'outFilterMismatchNmax' : args.outFilterMismatchNmax,
+            'fastq_left' : ','.join([os.path.join(x[0], x[1]) for x in align_sets[1]]),
+            'alignIntronMax' : args.alignIntronMax,
+            'alignMatesGapMax': args.alignMatesGapMax,
+            'sjdbScore': args.sjdbScore,
+            'alignSJDBoverhangMin' : args.alignSJDBoverhangMin,
+            'genomeLoad' : args.genomeLoad,
+            'readFilesCommand' : align_sets[0],
+            'outFilterMatchNminOverLread' : args.outFilterMatchNminOverLread,
+            'outFilterScoreMinOverLread' : args.outFilterScoreMinOverLread,
+            'sjdbOverhang' : args.sjdbOverhang,
+            'outSAMstrandField' : args.outSAMstrandField
+        })
+        if align_sets[2] == 'PE':
+            cmd = string.Template(cmd).substitute({
+                'fastq_right' : ','.join([os.path.join(x[0], x[2]) for x in align_sets[1]])
+            })
+
+        ### take temp directory from environment variable
+        if args.useTMP is not None:
+            align_dir_1st = os.path.abspath( tempfile.mkdtemp(dir=os.environ[args.useTMP], prefix="star_aligndir_1st_") )
+            genome_dir_1st = os.path.abspath( tempfile.mkdtemp(dir=os.environ[args.useTMP], prefix="star_genomedir_1st_") )
+        else:
+            align_dir_1st = os.path.abspath( tempfile.mkdtemp(dir=args.workDir, prefix="star_aligndir_1st_") )
+            genome_dir_1st = os.path.abspath( tempfile.mkdtemp(dir=args.workDir, prefix="star_genomedir_1st_") )
+        print "Running", cmd
+        subprocess.check_call(cmd, shell=True, cwd=align_dir_1st)
+
+        ### build index using provided genome fasta as well as junctions from first run
+        cmd = """STAR --runMode genomeGenerate --genomeDir %s \
+--genomeFastaFiles %s \
+--sjdbOverhang %i \
+--runThreadN %i \
+--sjdbFileChrStartEnd %s""" % (genome_dir_1st, args.genomeFastaFiles, args.sjdbOverhang, args.runThreadN, os.path.join(align_dir_1st, 'SJ.out.tab')) 
+        print "Running", cmd
+        subprocess.check_call(cmd, shell=True, cwd=align_dir_1st)
+
+        ### replace index for the second run with the one currently built
+        genome_dir = genome_dir_1st
+    else:
+        genome_dir = os.path.abspath(args.genomeDir)
+
+
     align_template_str = """STAR \
 --genomeDir ${genomeDir} --readFilesIn %s \
 --runThreadN ${runThreadN} \
@@ -184,7 +262,6 @@ if __name__ == "__main__":
 --readFilesCommand ${readFilesCommand} \
 --outFilterMatchNminOverLread ${outFilterMatchNminOverLread} \
 --outFilterScoreMinOverLread ${outFilterScoreMinOverLread} \
---twopass1readsN ${twopass1readsN} \
 --sjdbOverhang ${sjdbOverhang} \
 --outSAMstrandField ${outSAMstrandField} \
 --outSAMattributes ${outSAMattributes} \
@@ -192,8 +269,10 @@ if __name__ == "__main__":
 --outSAMtype ${outSAMtype} \
 --outSAMheaderHD ${outSAMheaderHD}""" % read_str
 
+#--twopass1readsN ${twopass1readsN} \
+
     cmd = string.Template(align_template_str).safe_substitute({
-        'genomeDir' : os.path.abspath(args.genomeDir),
+        'genomeDir' : genome_dir,
         'runThreadN' : args.runThreadN,
         'fastq_left' : ','.join([os.path.join(x[0], x[1]) for x in align_sets[1]]), #os.path.abspath(pair[1]),
         'outFilterMultimapScoreRange' : args.outFilterMultimapScoreRange,
@@ -207,7 +286,6 @@ if __name__ == "__main__":
         'readFilesCommand' : align_sets[0],
         'outFilterMatchNminOverLread' : args.outFilterMatchNminOverLread,
         'outFilterScoreMinOverLread' : args.outFilterScoreMinOverLread,
-        'twopass1readsN' : args.twopass1readsN,
         'sjdbOverhang' : args.sjdbOverhang,
         'outSAMstrandField' : args.outSAMstrandField,
         'outSAMattributes' : " ".join(args.outSAMattributes),
@@ -215,6 +293,7 @@ if __name__ == "__main__":
         'outSAMtype' : " ".join(args.outSAMtype),
         'outSAMheaderHD' : " ".join(args.outSAMheaderHD)
     })
+#        'twopass1readsN' : args.twopass1readsN,
     if align_sets[2] == 'PE':
         cmd = string.Template(cmd).substitute({
             'fastq_right' : ','.join([os.path.join(x[0], x[2]) for x in align_sets[1]]) # os.path.abspath(pair[2]),
@@ -238,10 +317,17 @@ if __name__ == "__main__":
             print >> sys.stderr, 'WARNING: %s does not exists - ignoring!'
         else:
             RG_dict = xml2RGdict(args.outSAMattrRGxml)
-            assert (len(align_sets[1]) == len(RG_dict['RG'])), 'Number of input file (pairs) does not match read groups in given RUN-xml' 
             rg_added = True
     if not rg_added:
         RG_dict = {'ID' : '', 'SM' : ''}
+
+    ### perform sanity check on provided RG records
+    if 'RG' in RG_dict:
+        if args.weakRGcheck and len(align_sets[1]) == 1 and len(RG_dict['RG']) > 1:
+            RG_dict['RG'] = [RG_dict['ID']]
+            print >> sys.stderr, 'WARNING: generated generic RG ID: %s' % RG_dict['ID']
+        else:
+            assert (len(align_sets[1]) == len(RG_dict['RG'])), 'Number of input file (pairs) does not match read groups in given RUN-xml' 
 
     ### post-process RG-dict to comply with STAR conventions
     for key in RG_dict:
@@ -268,6 +354,7 @@ if __name__ == "__main__":
     cmd += ' --outSAMattrRGline %s' % ' , '.join(RG_line)
 
     ### handle comment lines
+    comment_file = None
     if 'SI' in RG_dict:
         if args.useTMP is not None:
             comment_file = os.path.abspath( tempfile.mkstemp(dir=os.environ[args.useTMP], prefix="star_comments_")[1] )
@@ -306,4 +393,6 @@ if __name__ == "__main__":
     ### clean up working directory
     shutil.rmtree(workdir)
     shutil.rmtree(align_dir)
-    
+    if args.twopass1readsN != 0:
+        shutil.rmtree(align_dir_1st)
+        shutil.rmtree(genome_dir_1st)


### PR DESCRIPTION
The code in the PR contains the wrapper implementing the 2 pass alignment approach that has been used to create the STAR alignments. Further it provides the possibility to align given the metadata sheet and an analysis ID instead of an xml file. Last, the PR updates the STAR version that is used from 2.4.0f1 to 2.4.0g1.